### PR TITLE
Align responses with Matrix.org

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,16 +12,40 @@ use hyper::{Body, Method, Request, Response, Server, StatusCode};
 
 type BoxFut = Box<Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
+struct ErrorBody<'a> {
+    pub errcode: &'static str,
+    pub error: &'a str
+}
+impl<'a> ErrorBody<'a> {
+    const UNRECOGNIZED: ErrorBody<'static> = ErrorBody {
+        errcode: "M_UNRECOGNIZED",
+        error: "Unrecognized request"
+    };
+}
+impl<'a> ToString for ErrorBody<'a> {
+    fn to_string(&self) -> String {
+        json!({
+            "errcode": self.errcode,
+            "error": self.error
+        }).to_string()
+    }
+}
+
+const APPLICATION_JSON: &'static str = "application/json";
+
 fn handle_request(req: Request<Body>) -> BoxFut {
     let mut response = Response::new(Body::empty());
 
     match (req.method(), req.uri().path()) {
         (&Method::GET, "/_matrix/client/versions") => {
-            *response.status_mut() = StatusCode::NOT_FOUND;
+            *response.status_mut() = StatusCode::OK;
+            response.headers_mut().insert(hyper::header::CONTENT_TYPE, hyper::header::HeaderValue::from_static(APPLICATION_JSON));
             *response.body_mut() = Body::from(server_administration::versions().to_string());
         }
         _ => {
-            *response.status_mut() = StatusCode::NOT_FOUND;
+            *response.status_mut() = StatusCode::BAD_REQUEST;
+            response.headers_mut().insert(hyper::header::CONTENT_TYPE, hyper::header::HeaderValue::from_static(APPLICATION_JSON));
+            *response.body_mut() = Body::from(ErrorBody::UNRECOGNIZED.to_string());
         }
     };
 

--- a/src/server_administration.rs
+++ b/src/server_administration.rs
@@ -3,10 +3,8 @@ extern crate serde_json;
 /// Gets the versions of the specification supported by the server.
 pub fn versions() -> serde_json::Value {
     json!({
-        "application/json": {
-            "versions": [
-                "r0.3.0"
-            ]
-        }
+        "versions": [
+            "r0.3.0"
+        ]
     })
 }


### PR DESCRIPTION
- Replaced 404 with 400 and added a body.  There doesn't seem to be a spec for how to handle this, so I just looked at what matrix.org returns
- Added Content-type headers to responses
- Removed "application/json" key in versions response.  For some reason, the API docs page shows it, but the actual spec doesn't
- Fixed status code for versions response.  Unless I missed something, this should be 200